### PR TITLE
Expose generate, zig fmt, fix issue when not linking libc

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -44,7 +44,7 @@ pub fn build(b: *std.Build) void {
         b.step("parse", "Parse a .bfbs schema into ZON IR").dependOn(&run.step);
     }
 
-    const generate = b.createModule(.{
+    const generate = b.addModule("generate", .{
         .target = target,
         .optimize = optimize,
         .root_source_file = b.path("src/generate.zig"),

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -470,8 +470,7 @@ fn isInNamespace(namespace: ?[]const u8, name: []const u8) bool {
 
 pub fn main(
     init: std.process.Init,
-) !void 
-{
+) !void {
     const io = init.io;
 
     var args = init.minimal.args.iterate();
@@ -489,7 +488,7 @@ pub fn main(
     if (!std.mem.eql(u8, ir_filename[file_ext_index..], ".zon"))
         return error.InvalidFileExtension;
 
-    const file = try std.Io.Dir.cwd().openFile(io,ir_path, .{});
+    const file = try std.Io.Dir.cwd().openFile(io, ir_path, .{});
     defer file.close(io);
 
     const stat = try file.stat(io);
@@ -510,7 +509,7 @@ pub fn main(
         allocator,
         copy,
         null,
-        .{.ignore_unknown_fields = true}
+        .{ .ignore_unknown_fields = true },
     );
 
     // var parser = try Parser.init(std.heap.c_allocator, @alignCast(data));

--- a/src/generate.zig
+++ b/src/generate.zig
@@ -501,7 +501,7 @@ pub fn main(
         0,
     );
 
-    const allocator = std.heap.c_allocator;
+    const allocator = init.arena.allocator();
     const copy = try allocator.dupeZ(u8, data);
     defer allocator.free(copy);
     const schema = try std.zon.parse.fromSliceAlloc(

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -603,7 +603,7 @@ inline fn pop(name: []const u8) []const u8 {
 pub fn main(
     init: std.process.Init,
 ) !void {
-    const allocator = std.heap.c_allocator;
+    const allocator = init.arena.allocator();
     const io = init.io;
 
     var args = init.minimal.args.iterate();

--- a/src/parse.zig
+++ b/src/parse.zig
@@ -602,8 +602,7 @@ inline fn pop(name: []const u8) []const u8 {
 
 pub fn main(
     init: std.process.Init,
-) !void 
-{
+) !void {
     const allocator = std.heap.c_allocator;
     const io = init.io;
 
@@ -615,7 +614,7 @@ pub fn main(
         return;
     };
 
-    const file = try std.Io.Dir.cwd().openFile(io,schema_path, .{});
+    const file = try std.Io.Dir.cwd().openFile(io, schema_path, .{});
     defer file.close(io);
 
     const stat = try file.stat(io);


### PR DESCRIPTION
This also does a `zig fmt` of the `src/` dir and fixes an issue where the zig compiler would complain about using `std.heap.c_allocator` when not linking libc.

I want this exposed because in one of my projects I'm automating the creation of the module using the exposed modules from this.